### PR TITLE
Add workflow to run data tests

### DIFF
--- a/.github/workflows/data_tests.yml
+++ b/.github/workflows/data_tests.yml
@@ -1,0 +1,31 @@
+name: Data Tests
+
+on: [push, pull_request]
+
+jobs:
+  duplicate_entries:
+    name: Duplicate entries
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+
+    - name: Check out data
+      uses: actions/checkout@v2.3.4
+      with:
+        path: data
+
+    - name: Check out data tests
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: openelections/openelections-data-tests
+        ref: v0.1.1
+        path: data_tests
+
+    - name: Run data tests
+      run: python3 ${{ github.workspace }}/data_tests/run_tests.py duplicate_entries ${{ github.workspace }}/data

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-OpenElections Data WY [![Build Status](https://github.com/openelections/openelections-data-wy/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-wy/actions)
+[![Build Status](https://github.com/openelections/openelections-data-wy/actions/workflows/data_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-wy/actions)
+[![Build Status](https://github.com/openelections/openelections-data-wy/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-wy/actions)
+
+OpenElections Data WY
 =====================
 
 This repository contains certified election results for Wyoming elections, provided by the [Wyoming Secretary of State](http://soswy.state.wy.us). Most of the raw files are Excel files, although some from 2000 originally were Quattro Pro files and were converted to Excel format. The 2000 General Election files are in .wb3 format. Special election results are usually contained in PDF files, which are converted to CSV format.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://github.com/openelections/openelections-data-wy/actions/workflows/data_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-wy/actions)
-[![Build Status](https://github.com/openelections/openelections-data-wy/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-wy/actions)
+[![Build Status](https://github.com/openelections/openelections-data-wy/actions/workflows/data_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-wy/actions/workflows/data_tests.yml?query=branch%3Amaster)
+[![Build Status](https://github.com/openelections/openelections-data-wy/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-wy/actions/workflows/format_tests.yml?query=branch%3Amaster)
 
 OpenElections Data WY
 =====================


### PR DESCRIPTION
This adds a workflow to run the [data validation](https://github.com/openelections/openelections-data-tests) tests. This currently consists of a single job that checks for duplicate entries in the data files.